### PR TITLE
Fix dependencies of zenon

### DIFF
--- a/packages/lambdapi-zenon/lambdapi-zenon.0.0.0/opam
+++ b/packages/lambdapi-zenon/lambdapi-zenon.0.0.0/opam
@@ -12,8 +12,8 @@ dev-repo: "git+https://github.com/Deducteam/lambdapi-zenon.git"
 build: [ make ]
 install: [ make "install" ]
 depends: [
-  "lambdapi" {>= "2.3.0"}
-  "lambdapi-stdlib" {>= "1.1.0"}
+  "lambdapi" {>= "2.3.0" & <= "2.3.1"}
+  "lambdapi-stdlib" {= "1.1.0"}
 ]
 url {
   src:

--- a/packages/lambdapi-zenon/lambdapi-zenon.0.0.1/opam
+++ b/packages/lambdapi-zenon/lambdapi-zenon.0.0.1/opam
@@ -13,7 +13,7 @@ build: [ make ]
 install: [ make "install" ]
 depends: [
   "lambdapi" {>= "2.4.1"}
-  "lambdapi-stdlib" {>= "1.2.0"}
+  "lambdapi-stdlib" {= "1.2.0"}
 ]
 url {
   src:


### PR DESCRIPTION
## Fix dependencies of zenon

### Description

This commit fixes the dependency constraints for the `lambdapi-zenon` packages to ensure compatibility with specific versions of their dependencies.

### Changes

#### lambdapi-zenon 0.0.0
- Restrict `lambdapi` to `>= "2.3.0" & <= "2.3.1"` (instead of `>= "2.3.0"`)
- Change `lambdapi-stdlib` to exact version `= "1.1.0"` (instead of `>= "1.1.0"`)

#### lambdapi-zenon 0.0.1
- Change `lambdapi-stdlib` to exact version `= "1.2.0"` (instead of `>= "1.2.0"`)